### PR TITLE
Modify images (#17)

### DIFF
--- a/audit/audit.yaml
+++ b/audit/audit.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: kubecube-audit
-          image: hub.c.163.com/kubecube/audit:v1.0.0
+          image: hub.c.163.com/kubecube/audit:v1.0.1
           ports:
             - containerPort: 8888
           env:

--- a/frontend/frontend.yaml
+++ b/frontend/frontend.yaml
@@ -144,7 +144,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: hub.c.163.com/kubecube/frontend:v1.0.1
+          image: hub.c.163.com/kubecube/frontend:v1.0.2
           lifecycle:
             preStop:
               exec:

--- a/images/v1.18.20/images.list
+++ b/images/v1.18.20/images.list
@@ -1,7 +1,7 @@
-hub.c.163.com/kubecube/audit:v1.0.0
-hub.c.163.com/kubecube/cloudshell:v1.0.0
-hub.c.163.com/kubecube/webconsole:v1.0.0
-hub.c.163.com/kubecube/frontend:v1.0.1
+hub.c.163.com/kubecube/audit:v1.0.1
+hub.c.163.com/kubecube/cloudshell:v1.0.1
+hub.c.163.com/kubecube/webconsole:v1.0.1
+hub.c.163.com/kubecube/frontend:v1.0.2
 hub.c.163.com/kubecube/cube:v1.0.1
 hub.c.163.com/kubecube/warden:v1.0.0
 hub.c.163.com/kubecube/warden-init:v1.0.0

--- a/images/v1.19.13/images.list
+++ b/images/v1.19.13/images.list
@@ -1,7 +1,7 @@
-hub.c.163.com/kubecube/audit:v1.0.0
-hub.c.163.com/kubecube/cloudshell:v1.0.0
-hub.c.163.com/kubecube/webconsole:v1.0.0
-hub.c.163.com/kubecube/frontend:v1.0.1
+hub.c.163.com/kubecube/audit:v1.0.1
+hub.c.163.com/kubecube/cloudshell:v1.0.1
+hub.c.163.com/kubecube/webconsole:v1.0.1
+hub.c.163.com/kubecube/frontend:v1.0.2
 hub.c.163.com/kubecube/cube:v1.0.1
 hub.c.163.com/kubecube/warden:v1.0.0
 hub.c.163.com/kubecube/warden-init:v1.0.0

--- a/images/v1.20.9/images.list
+++ b/images/v1.20.9/images.list
@@ -1,7 +1,7 @@
-hub.c.163.com/kubecube/audit:v1.0.0
-hub.c.163.com/kubecube/cloudshell:v1.0.0
-hub.c.163.com/kubecube/webconsole:v1.0.0
-hub.c.163.com/kubecube/frontend:v1.0.1
+hub.c.163.com/kubecube/audit:v1.0.1
+hub.c.163.com/kubecube/cloudshell:v1.0.1
+hub.c.163.com/kubecube/webconsole:v1.0.1
+hub.c.163.com/kubecube/frontend:v1.0.2
 hub.c.163.com/kubecube/cube:v1.0.1
 hub.c.163.com/kubecube/warden:v1.0.0
 hub.c.163.com/kubecube/warden-init:v1.0.0

--- a/images/v1.21.2/images.list
+++ b/images/v1.21.2/images.list
@@ -1,7 +1,7 @@
-hub.c.163.com/kubecube/audit:v1.0.0
-hub.c.163.com/kubecube/cloudshell:v1.0.0
-hub.c.163.com/kubecube/webconsole:v1.0.0
-hub.c.163.com/kubecube/frontend:v1.0.1
+hub.c.163.com/kubecube/audit:v1.0.1
+hub.c.163.com/kubecube/cloudshell:v1.0.1
+hub.c.163.com/kubecube/webconsole:v1.0.1
+hub.c.163.com/kubecube/frontend:v1.0.2
 hub.c.163.com/kubecube/cube:v1.0.1
 hub.c.163.com/kubecube/warden:v1.0.0
 hub.c.163.com/kubecube/warden-init:v1.0.0

--- a/webconsole/webconsole.yaml
+++ b/webconsole/webconsole.yaml
@@ -20,7 +20,7 @@ spec:
             - name: JWT_SECRET
               value: 56F0D8DB90241C6E
           name: kubecube-webconsole
-          image: hub.c.163.com/kubecube/webconsole:v1.0.0-rc0
+          image: hub.c.163.com/kubecube/webconsole:v1.0.1
           ports:
             - containerPort: 9081
 ---
@@ -45,7 +45,7 @@ spec:
           name: localtime
       containers:
         - name: cloud-shell
-          image: hub.c.163.com/kubecube/cloudshell:v1.0.0-rc0
+          image: hub.c.163.com/kubecube/cloudshell:v1.0.1
           terminationMessagePath: "/dev/termination-log"
           terminationMessagePolicy: "File"
           imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
* Feature add configmap

* Feature hotplug

* Feature add crd label

* fix(charts): change thanos' chart name to kubecube-thanos

* modify front version from v1.0.0 to v1.0.1

* mv images.list to oss

* remove images.list

* fix cmd less

* skip download if docker binary already exist

* modify images

* move images.list back and modify frontend image

* add auth configmap (#12)

* add auth configmap

* fix param with value

* fix Cg== to empty string

* feat(monitoring): 1. upgrade kubecube-monitoring helm chart (#14)

2. add pre-fetch images

Signed-off-by: just1900 <legendj228@gmail.com>

* fix image of cube to v1.0.1 (#15)

* modify webconsole to v1.0.1, audit to v1.0.1, frontend to v1.0.2

Co-authored-by: fusida <821857511@qq.com>
Co-authored-by: zhujianfeng <echo_xidian@163.com>
Co-authored-by: just1900 <legendj228@gmail.com>
Co-authored-by: JiahuiZhao11 <41603640+JiahuiZhao11@users.noreply.github.com>